### PR TITLE
fixed yaml.load_file in R

### DIFF
--- a/LoadingData.Rmd
+++ b/LoadingData.Rmd
@@ -32,7 +32,7 @@ head(csv_data)
 Excel spreadsheets are more complicated than CSV (ex they can contain multiple datasets), but they still follow the 2D array format of a CSV and DataFrames
 
 ```{r}
-require(readxl)
+library(readxl)
 xlsx_data <- read_excel("data/volcanoes.xlsx") #sheet=0
 head(xlsx_data)
 ```
@@ -63,9 +63,9 @@ YAML has less overhead than JSON and can reference other objects within the same
 
 ```{r}
 library(yaml)
-#yaml_data <- yaml.load_file("data/volcanoes.yml", handlers = list(map = function(x) { as.data.frame(x) }))
-#head(yaml_data)
-#Not yet working
+yaml_data <- yaml.load_file("data/volcanoes.yml", handlers = list(map = function(x) { as.data.frame(x) }))
+yaml_data <- do.call("rbind", yaml_data)
+head(yaml_data)
 ```
 
 ## .rda — R Data


### PR DESCRIPTION
It was bugging the hell out of me at the meetup. You were right to have as.data.frame passed to yaml.load_file. This returns a list of data frames. The only thing we were missing is to have all of the data frames unlisted and bound by rows ("rebind", yaml_data). Also, changed require(package_name) to library(package_name). Require checks to see if a package can be loaded, but does not load it.